### PR TITLE
Change image size for icon weather

### DIFF
--- a/src/sass/components/_weather.scss
+++ b/src/sass/components/_weather.scss
@@ -136,15 +136,16 @@
       line-height: 23px;
     }
   }
-  &__image {
-    width: 128px;
-    height: 121px;
+     &__image { 
+    width: 168px;
+    margin-bottom: 20px;
     display: block;
-    margin: auto;
+    margin-left: auto;
+    margin-right: auto;
 
     @include tablet {
-    width: 165px;
-    height: 156px;
+        width: 205px;
+    margin-bottom: 65px;
     }
   }
 }


### PR DESCRIPTION
Вибач, якось не додивилась за розміром іконки стану погоди, виправила, зробила більший розмір, хоча по макету не зробиш один в один, бо АПІ видає зображення із рамкою, а на макеті без. Зробила приблизно по макету